### PR TITLE
tmux: press ^B \ to reorder two windows, hsplit <-> vspilt

### DIFF
--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -31,6 +31,9 @@ bind C-s set-window-option synchronize-panes
 bind | split-window -hc "#{pane_current_path}"
 bind - split-window -vc "#{pane_current_path}"
 
+# reorder {bottom|right} of two windows, swap beteen horizontal and vertical split
+bind \\ run-shell "~/bin/tmux_reorder_adj_windows.sh 2>&1"
+
 # Pane seperators: tmux 3.2
 set -q -g pane-border-lines double
 

--- a/home/bin/tmux_reorder_adj_windows.sh
+++ b/home/bin/tmux_reorder_adj_windows.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+H=$(tmux display -p '#{pane_height}')
+if [[ "$H" == "" ]]; then
+    exit 1
+fi
+
+if [[ "$H" -le 9 ]]; then
+    tmux move-pane -t {up-of} -h
+else
+    tmux move-pane -t {left-of} -v
+fi


### PR DESCRIPTION
Select the bottom/right window; press ^B \ ; The window is now right/bottom.

The window is recognized as "bottom" if it is 9 lines or less.

Other windows are not affected.

https://github.com/user-attachments/assets/677c9e95-5b50-4870-ad45-cb69e7c60075

